### PR TITLE
Fixed issue #11 where Military Outpost was not shown as class "Planet"

### DIFF
--- a/data/displayText.json
+++ b/data/displayText.json
@@ -115,5 +115,6 @@
     "bandit-interceptor":"\"Bandit\" Interceptor", 
     "tactical-adjunct":"Tactical Adjunct",
     "cut-throat":"Cut Throat",
-    "lord-commander":"Lord Commander"
+    "lord-commander":"Lord Commander",
+    "planet":"Planet"
 }


### PR DESCRIPTION
displayText for "planet" was simply missing, adding it fixed issue #11 