### PR TITLE
Add a checkbox for ScoutBox content

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,8 @@
             <button onclick="openForceWindow()">Load Force</button>
             <input type="checkbox" id="content-campaign" name="campaign">
             <label for="content-campaign">Include Campaign Content</label>
+            <input type="checkbox" id="content-scoutbox" name="scoutbox">
+            <label for="content-scoutbox">Include Scout Box Content</label>
         </div>
     </div>
     <div id="warnings"></div>


### PR DESCRIPTION
Very straightforward. Adds an additional checkbox for toggling Scoutbox content on/off. I did a quick check of toggling on/off the different states of campaign and scoutbox, and all combinations seem to be working properly.

closes #10 