### PR TITLE
Moved Military Outpost from ships to planets data file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/data/planets.json
+++ b/data/planets.json
@@ -1,5 +1,23 @@
 [
     {
+        "name":"military-outpost",
+        "class":"planet",
+        "cost":4,
+        "slots": [
+            {
+                "class":"fighter",
+                "purchase":"optional",
+                "count": 2
+            },
+            {
+                "class":"strike-craft",
+                "purchase":"optional",
+                "count": 2
+            }
+        ],
+        "source":"base"
+    },
+    {
         "name":"industrial-world",
         "cost":4,
         "class":"planet",
@@ -18,7 +36,8 @@
                 "class":"fighter",
                 "purchase":"optional"
             }
-        ]
+        ],
+        "source":"campaign"
     },
     {
         "name":"established-colony",
@@ -38,7 +57,8 @@
                 "class":"fighter",
                 "purchase":"optional"
             }
-        ]
+        ],
+        "source":"campaign"
     },
     {
         "name":"new-settlement",
@@ -54,7 +74,8 @@
                 "class":"fighter",
                 "purchase":"optional"
             }
-        ]
+        ],
+        "source":"campaign"
     },
     {
         "name":"civilised-world",
@@ -75,6 +96,7 @@
                 "class":"fighter",
                 "purchase":"optional"
             }
-        ]
+        ],
+        "source":"campaign"
     }
 ]

--- a/data/ships.json
+++ b/data/ships.json
@@ -126,25 +126,6 @@
         "source":"base"
     },
     {
-        "name":"military-outpost",
-        "class":"planet",
-        "faction":["kushan","taiidan", "kadesh", "turanic-raiders"],
-        "cost":4,
-        "slots": [
-            {
-                "class":"fighter",
-                "purchase":"optional",
-                "count": 2
-            },
-            {
-                "class":"strike-craft",
-                "purchase":"optional",
-                "count": 2
-            }
-        ],
-        "source":"base"
-    },
-    {
         "name":"weapons-platform",
         "class":"platform",
         "faction":["kushan","taiidan", "kadesh", "turanic-raiders"],

--- a/hfcufb.js
+++ b/hfcufb.js
@@ -1151,19 +1151,19 @@ function setupOptions(){
     unitSection.appendChild(unitAddButton);
 
     var planetSection = document.getElementById("addPlanetSection");
-    if(!contentCampaign.checked){
-        planetSection.classList.add("noDisplay");
-    } else {
-        planetSection.classList.remove("noDisplay")
-    }
+
     var planetLabel = document.createElement("span");
     planetLabel.innerHTML = "Planets:";
     planetSection.appendChild(planetLabel);
 
     planetDropdown = document.createElement("SELECT");
     planets.forEach(function(planet){
-        var option = new Option(displayText[planet.name] + " (" + planet.cost + ")", planet.name);
-        planetDropdown.add(option);
+
+         // Military Outpost is the only base game planet, so we only show that if no additional content is activated
+        if(validSource(planet)){
+            var option = new Option(displayText[planet.name] + " (" + planet.cost + ")", planet.name);
+            planetDropdown.add(option);
+        }
     });
     planetSection.appendChild(planetDropdown);
 


### PR DESCRIPTION
This required showing the "Planets" selector also if the campaign expansion was not activated (i.e., its checkbox is unchecked).

This required that all planets have a "source" field, which was added with source="campaign" for the 4 campaign expansion planets. The Military Outpost already had this from it's time as a unit.

This addresses issue #21