### PR TITLE
Fixed wrong-faction-warning that did not use displayText for faction name

### DIFF
--- a/hfcufb.js
+++ b/hfcufb.js
@@ -617,7 +617,7 @@ function renderUnit(unit, unitCount, unitSection){
 
     if(unitData.faction.indexOf(force.faction) < 0){
         var factionWarningdiv = document.createElement("span");
-        factionWarningdiv.innerHTML = "⚠ This Unit is not available for the " + force.faction + " faction";
+        factionWarningdiv.innerHTML = "⚠ This Unit is not available for the " + displayText[force.faction] + " faction";
         unitWarningDiv.appendChild(factionWarningdiv);
     }
 


### PR DESCRIPTION
This addresses issue #20