### PR TITLE
Nomenclature fixes

### DIFF
--- a/hfcufb.js
+++ b/hfcufb.js
@@ -472,11 +472,11 @@ function renderUnit(unit, unitCount, unitSection){
     commanderSection.classList.add("commanderSection");
 
     var unitCommanderLabel = document.createElement("span");
-    unitCommanderLabel.innerHTML = "Commander:";
+    unitCommanderLabel.innerHTML = "Leader:";
     commanderSection.appendChild(unitCommanderLabel);
 
     var leaderOptions = document.createElement("SELECT");
-    leaderOptions.add(new Option("No Commander", null));
+    leaderOptions.add(new Option("No Leader", null));
     force.leaders.forEach(function(leader){
         var leaderData = getLeaderData(leader.leaderId);
         if((leader.assignedUnit == null  || unit.commander == leader.uniqueCode)
@@ -618,7 +618,7 @@ function renderUnit(unit, unitCount, unitSection){
 
     if(unslottedUnits.indexOf(unit) >= 0){
         var slotWarningdiv = document.createElement("span");
-        slotWarningdiv.innerHTML = "⚠ This Unit is not in any available slot"
+        slotWarningdiv.innerHTML = "⚠ There is no Unit Tab available for this unit."
         unitWarningDiv.appendChild(slotWarningdiv);
     }
 

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         <div id="unitsSection">
             <span>Units</span>
             <div id="units"></div>
-            <span>Empty Slots</span>
+            <span>Empty Unit Tabs</span>
             <div id="emptySlots"></div>
         </div>
     </div>


### PR DESCRIPTION
"Unit Tabs" is so awkward to say, heh. Sticking with "slots" in the code for the time being. Used "Commander" as a way to differentiate the Leader in charge of the unit from Staff, but the issue is correct: the squad builder should use the nomenclature from the rules.

closes #18
closes #19 