### PR TITLE
Units can be marked in reserve, with tracked star totals

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
             <span id="totalHand">0</span>
             <label for="totalPlay">Play:</label>
             <span id="totalPlay">0</span>
+            <label for="mainForceCost">Main Force Cost:</label>
+            <span id="mainForceCost">0</span>
+            <label for="reservesCost">Reserves Cost:</label>
+            <span id="reservesCost">0</span>
         </div>
         <div id="headerButtons">
             <button onclick="newForce()">New Force</button>


### PR DESCRIPTION
You can now mark a unit as being in reserves. Costs are calculated for the entire force, but also for the main force and the reserves.

closes #22 